### PR TITLE
Use global::System references & %localappdata%

### DIFF
--- a/Source/LinqToVfpLinqPadDriver/CodeGeneration/EntityCodeGen.cs
+++ b/Source/LinqToVfpLinqPadDriver/CodeGeneration/EntityCodeGen.cs
@@ -41,7 +41,7 @@ namespace LinqToVfpLinqPadDriver.CodeGeneration {
         private void WriteColumns() {
             foreach (var column in _schemaObject.Columns.Values.Cast<VfpColumn>()) {
                 WriteTab();
-                Write("public System.");
+                Write("public global::System.");
                 WriteClrType(column);
                 Write(" ");
                 Write(column.PropertyName);

--- a/Source/LinqToVfpLinqPadDriver/LinqToVfpLinqPadDriver.csproj
+++ b/Source/LinqToVfpLinqPadDriver/LinqToVfpLinqPadDriver.csproj
@@ -84,6 +84,7 @@
     </Compile>
     <Compile Include="CodeGeneration\DataContextCodeGen.cs" />
     <Compile Include="CodeGeneration\EntityCodeGen.cs" />
+    <None Include="Schema\blah.cs" />
     <Compile Include="Schema\EntityMemberProvider.cs" />
     <Compile Include="Schema\PrimaryKey.cs" />
     <Compile Include="Schema\SchemaBuilder.cs" />
@@ -125,7 +126,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>xcopy "$(TargetDir)LinqToVfpLinqPadDriver.*" "C:\Users\Tom\AppData\Local\LINQPad\Drivers\DataContext\4.6\LinqToVfpLinqPadDriver (38cb6d207d4a86bc)" /y</PostBuildEvent>
+    <PostBuildEvent>xcopy "$(TargetDir)LinqToVfpLinqPadDriver.*" "%25localappdata%25\LINQPad\Drivers\DataContext\4.6\LinqToVfpLinqPadDriver (38cb6d207d4a86bc)" /y</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Source/LinqToVfpLinqPadDriver/LinqToVfpLinqPadDriver.csproj
+++ b/Source/LinqToVfpLinqPadDriver/LinqToVfpLinqPadDriver.csproj
@@ -84,7 +84,6 @@
     </Compile>
     <Compile Include="CodeGeneration\DataContextCodeGen.cs" />
     <Compile Include="CodeGeneration\EntityCodeGen.cs" />
-    <None Include="Schema\blah.cs" />
     <Compile Include="Schema\EntityMemberProvider.cs" />
     <Compile Include="Schema\PrimaryKey.cs" />
     <Compile Include="Schema\SchemaBuilder.cs" />


### PR DESCRIPTION
- Use `global::System` references, fixes #1 
- Use %localappdata% to ease developer setup